### PR TITLE
Add raw query support with PostgreSQL native placeholders

### DIFF
--- a/psycopg/psycopg/__init__.py
+++ b/psycopg/psycopg/__init__.py
@@ -24,6 +24,7 @@ from .transaction import Rollback, Transaction, AsyncTransaction
 from .cursor_async import AsyncCursor
 from .server_cursor import AsyncServerCursor, ServerCursor
 from .client_cursor import AsyncClientCursor, ClientCursor
+from .raw_cursor import AsyncRawCursor, RawCursor
 from .connection_async import AsyncConnection
 
 from . import dbapi20
@@ -64,6 +65,7 @@ __all__ = [
     "AsyncCopy",
     "AsyncCursor",
     "AsyncPipeline",
+    "AsyncRawCursor",
     "AsyncServerCursor",
     "AsyncTransaction",
     "BaseConnection",
@@ -76,6 +78,7 @@ __all__ = [
     "IsolationLevel",
     "Notify",
     "Pipeline",
+    "RawCursor",
     "Rollback",
     "ServerCursor",
     "Transaction",

--- a/psycopg/psycopg/raw_cursor.py
+++ b/psycopg/psycopg/raw_cursor.py
@@ -1,0 +1,60 @@
+"""
+psycopg raw queries cursors
+"""
+
+# Copyright (C) 2023 The Psycopg Team
+
+from typing import Any, Optional, Sequence, Tuple, List, TYPE_CHECKING
+from functools import lru_cache
+
+from ._queries import PostgresQuery, QueryPart
+
+from .abc import ConnectionType, Query, Params
+from .rows import Row
+from .cursor import BaseCursor, Cursor
+from ._enums import PyFormat
+from .cursor_async import AsyncCursor
+
+if TYPE_CHECKING:
+    from .connection import Connection  # noqa: F401
+    from .connection_async import AsyncConnection  # noqa: F401
+
+
+class RawPostgresQuery(PostgresQuery):
+    @staticmethod
+    @lru_cache()
+    def query2pg(
+        query: bytes, encoding: str
+    ) -> Tuple[bytes, Optional[List[PyFormat]], Optional[List[str]], List[QueryPart]]:
+        """
+        Noop; Python raw query is already in the format Postgres understands.
+        """
+        return query, None, None, []
+
+    @staticmethod
+    def validate_and_reorder_params(
+        parts: List[QueryPart], vars: Params, order: Optional[List[str]]
+    ) -> Sequence[Any]:
+        """
+        Verify the compatibility; params must be a sequence for raw query.
+        """
+        if not PostgresQuery.is_params_sequence(vars):
+            raise TypeError("raw query require a sequence of parameters")
+        return vars
+
+
+class RawCursorMixin(BaseCursor[ConnectionType, Row]):
+    def _convert_query(
+        self, query: Query, params: Optional[Params] = None
+    ) -> PostgresQuery:
+        pgq = RawPostgresQuery(self._tx)
+        pgq.convert(query, params)
+        return pgq
+
+
+class RawCursor(RawCursorMixin["Connection[Any]", Row], Cursor[Row]):
+    __module__ = "psycopg"
+
+
+class AsyncRawCursor(RawCursorMixin["AsyncConnection[Any]", Row], AsyncCursor[Row]):
+    __module__ = "psycopg"

--- a/tests/fix_faker.py
+++ b/tests/fix_faker.py
@@ -146,7 +146,7 @@ class Faker:
             with conn.transaction():
                 yield
         except psycopg.DatabaseError:
-            cur = conn.cursor()
+            cur = psycopg.Cursor(conn)
             # Repeat insert one field at time, until finding the wrong one
             cur.execute(self.drop_stmt)
             cur.execute(self.create_stmt)
@@ -171,7 +171,7 @@ class Faker:
             async with aconn.transaction():
                 yield
         except psycopg.DatabaseError:
-            acur = aconn.cursor()
+            acur = psycopg.AsyncCursor(aconn)
             # Repeat insert one field at time, until finding the wrong one
             await acur.execute(self.drop_stmt)
             await acur.execute(self.create_stmt)

--- a/tests/test_raw_cursor.py
+++ b/tests/test_raw_cursor.py
@@ -1,0 +1,112 @@
+import pytest
+import psycopg
+from psycopg import pq, rows, errors as e
+from psycopg.adapt import PyFormat
+
+from .test_cursor import ph
+from .utils import gc_collect, gc_count
+
+
+@pytest.fixture
+def conn(conn):
+    conn.cursor_factory = psycopg.RawCursor
+    return conn
+
+
+def test_default_cursor(conn):
+    cur = conn.cursor()
+    assert type(cur) is psycopg.RawCursor
+
+
+def test_str(conn):
+    cur = conn.cursor()
+    assert "psycopg.RawCursor" in str(cur)
+
+
+def test_sequence_only(conn):
+    cur = conn.cursor()
+    cur.execute("select 1", ())
+    assert cur.fetchone() == (1,)
+
+    with pytest.raises(TypeError, match="sequence"):
+        cur.execute("select 1", {})
+
+
+def test_execute_many_results_param(conn):
+    cur = conn.cursor()
+    # Postgres raises SyntaxError, CRDB raises InvalidPreparedStatementDefinition
+    with pytest.raises((e.SyntaxError, e.InvalidPreparedStatementDefinition)):
+        cur.execute("select $1; select generate_series(1, $2)", ("foo", 3))
+
+
+def test_query_params_execute(conn):
+    cur = conn.cursor()
+    assert cur._query is None
+
+    cur.execute("select $1, $2::text", [1, None])
+    assert cur._query is not None
+    assert cur._query.query == b"select $1, $2::text"
+    assert cur._query.params == [b"\x00\x01", None]
+
+    cur.execute("select 1")
+    assert cur._query.query == b"select 1"
+    assert not cur._query.params
+
+    with pytest.raises(psycopg.DataError):
+        cur.execute("select $1::int", ["wat"])
+
+    assert cur._query.query == b"select $1::int"
+    assert cur._query.params == [b"wat"]
+
+
+def test_query_params_executemany(conn):
+    cur = conn.cursor()
+
+    cur.executemany("select $1, $2", [[1, 2], [3, 4]])
+    assert cur._query.query == b"select $1, $2"
+    assert cur._query.params == [b"\x00\x03", b"\x00\x04"]
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("fmt", PyFormat)
+@pytest.mark.parametrize("fmt_out", pq.Format)
+@pytest.mark.parametrize("fetch", ["one", "many", "all", "iter"])
+@pytest.mark.parametrize("row_factory", ["tuple_row", "dict_row", "namedtuple_row"])
+def test_leak(conn_cls, dsn, faker, fmt, fmt_out, fetch, row_factory):
+    faker.format = fmt
+    faker.choose_schema(ncols=5)
+    faker.make_records(10)
+    row_factory = getattr(rows, row_factory)
+
+    def work():
+        with conn_cls.connect(dsn) as conn, conn.transaction(force_rollback=True):
+            with conn.cursor(binary=fmt_out, row_factory=row_factory) as cur:
+                cur.execute(faker.drop_stmt)
+                cur.execute(faker.create_stmt)
+                with faker.find_insert_problem(conn):
+                    cur.executemany(faker.insert_stmt, faker.records)
+                cur.execute(ph(cur, faker.select_stmt))
+
+                if fetch == "one":
+                    while True:
+                        tmp = cur.fetchone()
+                        if tmp is None:
+                            break
+                elif fetch == "many":
+                    while True:
+                        tmp = cur.fetchmany(3)
+                        if not tmp:
+                            break
+                elif fetch == "all":
+                    cur.fetchall()
+                elif fetch == "iter":
+                    for rec in cur:
+                        pass
+
+    n = []
+    gc_collect()
+    for i in range(3):
+        work()
+        gc_collect()
+        n.append(gc_count())
+    assert n[0] == n[1] == n[2], f"objects leaked: {n[1] - n[0]}, {n[2] - n[1]}"

--- a/tests/test_raw_cursor_async.py
+++ b/tests/test_raw_cursor_async.py
@@ -1,0 +1,113 @@
+import pytest
+import psycopg
+from psycopg import pq, rows, errors as e
+from psycopg.adapt import PyFormat
+
+from .test_cursor import ph
+from .utils import gc_collect, gc_count
+
+
+@pytest.fixture
+async def aconn(aconn, anyio_backend):
+    aconn.cursor_factory = psycopg.AsyncRawCursor
+    return aconn
+
+
+async def test_default_cursor(aconn):
+    cur = aconn.cursor()
+    assert type(cur) is psycopg.AsyncRawCursor
+
+
+async def test_str(aconn):
+    cur = aconn.cursor()
+    assert "psycopg.AsyncRawCursor" in str(cur)
+
+
+async def test_sequence_only(aconn):
+    cur = aconn.cursor()
+    await cur.execute("select 1", ())
+    assert await cur.fetchone() == (1,)
+
+    with pytest.raises(TypeError, match="sequence"):
+        await cur.execute("select 1", {})
+
+
+async def test_execute_many_results_param(aconn):
+    cur = aconn.cursor()
+    # Postgres raises SyntaxError, CRDB raises InvalidPreparedStatementDefinition
+    with pytest.raises((e.SyntaxError, e.InvalidPreparedStatementDefinition)):
+        await cur.execute("select $1; select generate_series(1, $2)", ("foo", 3))
+
+
+async def test_query_params_execute(aconn):
+    cur = aconn.cursor()
+    assert cur._query is None
+
+    await cur.execute("select $1, $2::text", [1, None])
+    assert cur._query is not None
+    assert cur._query.query == b"select $1, $2::text"
+    assert cur._query.params == [b"\x00\x01", None]
+
+    await cur.execute("select 1")
+    assert cur._query.query == b"select 1"
+    assert not cur._query.params
+
+    with pytest.raises(psycopg.DataError):
+        await cur.execute("select $1::int", ["wat"])
+
+    assert cur._query.query == b"select $1::int"
+    assert cur._query.params == [b"wat"]
+
+
+async def test_query_params_executemany(aconn):
+    cur = aconn.cursor()
+
+    await cur.executemany("select $1, $2", [[1, 2], [3, 4]])
+    assert cur._query.query == b"select $1, $2"
+    assert cur._query.params == [b"\x00\x03", b"\x00\x04"]
+
+
+@pytest.mark.slow
+@pytest.mark.parametrize("fmt", PyFormat)
+@pytest.mark.parametrize("fmt_out", pq.Format)
+@pytest.mark.parametrize("fetch", ["one", "many", "all", "iter"])
+@pytest.mark.parametrize("row_factory", ["tuple_row", "dict_row", "namedtuple_row"])
+async def test_leak(aconn_cls, dsn, faker, fmt, fmt_out, fetch, row_factory):
+    faker.format = fmt
+    faker.choose_schema(ncols=5)
+    faker.make_records(10)
+    row_factory = getattr(rows, row_factory)
+
+    async def work():
+        async with await aconn_cls.connect(dsn) as aconn:
+            async with aconn.transaction(force_rollback=True):
+                async with aconn.cursor(binary=fmt_out, row_factory=row_factory) as cur:
+                    await cur.execute(faker.drop_stmt)
+                    await cur.execute(faker.create_stmt)
+                    async with faker.find_insert_problem_async(aconn):
+                        await cur.executemany(faker.insert_stmt, faker.records)
+                    await cur.execute(ph(cur, faker.select_stmt))
+
+                    if fetch == "one":
+                        while True:
+                            tmp = await cur.fetchone()
+                            if tmp is None:
+                                break
+                    elif fetch == "many":
+                        while True:
+                            tmp = await cur.fetchmany(3)
+                            if not tmp:
+                                break
+                    elif fetch == "all":
+                        await cur.fetchall()
+                    elif fetch == "iter":
+                        async for rec in cur:
+                            pass
+
+    n = []
+    gc_collect()
+    for i in range(3):
+        await work()
+        gc_collect()
+        n.append(gc_count())
+    assert n[0] == n[1] == n[2], f"objects leaked: {n[1] - n[0]}, {n[2] - n[1]}"


### PR DESCRIPTION
Recreated from original PR: https://github.com/psycopg/psycopg/pull/560

This commit introduces support for raw queries with PostgreSQL's native placeholders ($1, $2, etc.) in psycopg3. By setting the use_raw_query attribute to True in a custom cursor class, users can enable the use of raw queries with native placeholders.

The code demonstrates how to create a custom RawQueryCursor class that sets the use_raw_query attribute to True. This custom cursor class can be set as the cursor_factory when connecting to the database, allowing users to choose between PostgreS...